### PR TITLE
added monitor_completion flag to check for search completion

### DIFF
--- a/pymzn/tests/marsh_test.py
+++ b/pymzn/tests/marsh_test.py
@@ -52,3 +52,7 @@ class MarshTest(unittest.TestCase):
 
     def test_rebase_array(self):
         self.assertEqual(pymzn.rebase_array({2: 1, 3: 2, 4: 3}), [1, 2, 3])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pymzn/tests/parse_test.py
+++ b/pymzn/tests/parse_test.py
@@ -42,3 +42,7 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(parsed['x14'], {2: [1, 2, 3], 3: [4, 5, 6]})
         self.assertEqual(parsed['x15'],
                          [{2: 1, 3: 2, 4: 3}, {2: 4, 3: 5, 4: 6}])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I often set time limits for pymzn.minizinc calls on constraint satisfaction problems with multiple solutions. 
This means the solver may return before all solutions have been found.

To avoid thinking the solver returned all solutions when it doesn't, a monitor_completion bool flag is added to both pymzn.minizinc and pymzn.solns2out. It is False by default so it shouldn't affect previous behaviour.


I also added small snippets to the tests so I could launch them from command line.