### PR TITLE
minizinc: fix typo.

### DIFF
--- a/pymzn/_mzn/_minizinc.py
+++ b/pymzn/_mzn/_minizinc.py
@@ -379,7 +379,7 @@ def solns2out(soln_stream, ozn_file, check_complete=False):
         else:
             curr_out.append(line)
 
-    log.debug('Solutions found: {}', len(soln))
+    log.debug('Solutions found: {}', len(solns))
 
     if check_complete:
         return solns, complete


### PR DESCRIPTION
Fixes this exception:

Traceback (most recent call last):
  [...]
  File "/home/stefano/.local/lib/python3.5/site-packages/pymzn-0.11.4-py3.5.egg/pymzn/_mzn/_minizinc.py", line 382, in solns2out
UnboundLocalError: local variable 'soln' referenced before assignment