### PR TITLE
close temp .mzn file

### DIFF
--- a/pymzn/mzn/minizinc.py
+++ b/pymzn/mzn/minizinc.py
@@ -181,6 +181,8 @@ def minizinc(mzn, *dzn_files, data=None, keep=False, include=None, solver=gecode
                                      suffix='.mzn', delete=False, mode='w+',
                                      buffering=1)
     mzn_model.compile(output_file)
+    output_file.close()
+    
     mzn_file = output_file.name
     data_file = None
     fzn_file = None

--- a/pymzn/tests/test_minizinc.py
+++ b/pymzn/tests/test_minizinc.py
@@ -121,3 +121,8 @@ class MinizincTest(unittest.TestCase):
                                    'capacity': 20})
         self.assertEqual(list(out), [{'x': {3, 5}}])
 
+    def test_minizinc2(self):
+        # test that the temp file is flushed or closed
+        # somehow the file is flushed if there is a \n in the string written
+        out = list(pymzn.minizinc("var 1 .. 1: x; solve maximize x;"))
+        self.assertEqual(list(out), [{'x': 1}])


### PR DESCRIPTION
Close the temporary .mzn file. If this is not done, the contents on
disc might not be complete. And it will cause problems on Windows.