### PR TITLE
Fixed bug: default arg timeout=True instead of timeout=None

### DIFF
--- a/pymzn/process.py
+++ b/pymzn/process.py
@@ -183,7 +183,7 @@ class Process:
                 stdout, stderr = self.stdout_data, self.stderr_data
                 raise CalledProcessError(retcode, self.args, stdout, stderr)
 
-    def start(self, stdin=None, timeout=True):
+    def start(self, stdin=None, timeout=None):
         """Starts the process asynchronously.
 
         Parameters


### PR DESCRIPTION
Default argument of timeout in process.py was "True" instead of "None", setting the default timeout to 1s.