### PR TITLE
Remove comments from DZN before splitting into statements

### DIFF
--- a/pymzn/dzn/eval.py
+++ b/pymzn/dzn/eval.py
@@ -146,9 +146,9 @@ def dzn2dict(dzn, *, rebase_arrays=True):
             dzn = f.read()
 
     assign = {}
+    dzn = _comm_p.sub('\n', dzn)
     stmts = _stmt_p.findall(dzn)
     for stmt in stmts:
-        stmt = _comm_p.sub('', stmt)
         var_m = _var_p.match(stmt)
         if var_m:
             var = var_m.group('var')

--- a/pymzn/tests/test_parse.py
+++ b/pymzn/tests/test_parse.py
@@ -14,7 +14,7 @@ class EvalTest(unittest.TestCase):
             x6 = 1..3;
             x7 = []; x8 =
              array1d({}, []);
-            x9 = [1, 2, 3];
+            x9 = [1, 2, 3];  % Another comment
             x10 = [{1, 2}, {3, 4}];
             x11 = array1d(1..3,
              [1, 2, 3]);

--- a/pymzn/tests/test_parse.py
+++ b/pymzn/tests/test_parse.py
@@ -8,6 +8,7 @@ class EvalTest(unittest.TestCase):
 
     def test_eval_dzn(self):
         dzn = dedent('''\
+            % This is a comment; with a semicolon
             x1 = 1;x2 = 1.0; x3 = -1.5;
             x4 = {};
             x5 = {1, 3};


### PR DESCRIPTION
Function `dzn.dzn2dict`:
If a comment contained a semicolon, the regex expression tried to parse the comment after the semicolon as a statement, which fails.

This pull request removes comments from the DZN before it is parsed for statements.

A real example where this problem occurs:
https://github.com/MiniZinc/minizinc-benchmarks/blob/master/jobshop/jobshop_la06.dzn