### PR TITLE
DZN parsing with sets containing only spaces

### DIFF
--- a/pymzn/dzn/eval.py
+++ b/pymzn/dzn/eval.py
@@ -115,7 +115,7 @@ def _eval_val(val):
     # integer set
     set_m = _int_set_p.match(val)
     if set_m:
-        vals = set_m.group('vals')
+        vals = set_m.group('vals').strip()
         if vals:
             return _eval_set(vals.split(','))
         return set()

--- a/pymzn/tests/test_parse.py
+++ b/pymzn/tests/test_parse.py
@@ -11,6 +11,7 @@ class EvalTest(unittest.TestCase):
             % This is a comment; with a semicolon
             x1 = 1;x2 = 1.0; x3 = -1.5;
             x4 = {};
+            x4a = {  };
             x5 = {1, 3};
             x6 = 1..3;
             x7 = []; x8 =
@@ -31,6 +32,7 @@ class EvalTest(unittest.TestCase):
         self.assertEqual(obj['x2'], 1.0)
         self.assertEqual(obj['x3'], -1.5)
         self.assertEqual(obj['x4'], set())
+        self.assertEqual(obj['x4a'], set())
         self.assertEqual(obj['x5'], {1, 3})
         self.assertEqual(obj['x6'], {1, 2, 3})
         self.assertEqual(obj['x7'], [])


### PR DESCRIPTION
Sets that contained only spaces, e.g. `x4a = {  };`, could not be parsed by `dzn2dict`.

The change calls the `strip` function to remove spaces before deciding whether parsing is necessary, this fixes the bug.

A small test is included to illustrate the issue.