### PR TITLE
Fixed model flattening generating no fzn and ozn file

### DIFF
--- a/pymzn/mzn/minizinc.py
+++ b/pymzn/mzn/minizinc.py
@@ -294,7 +294,7 @@ def minizinc(
                 output_mode=_output_mode
             )
             solver_stream, stderr = _solve(
-                solver, fzn_file, wait=wait, timeout=timeout, output_mode='dzn',
+                solver, fzn_file or mzn_file, wait=wait, timeout=timeout, output_mode='dzn',
                 all_solutions=all_solutions, num_solutions=num_solutions,
                 statistics=statistics, **solver_args
             )


### PR DESCRIPTION
`_solve` (Or rather, the functions that `_solve` calls further down the execution chain) expects its `mzn_file` parameter to be strings, but `None` may be returned as `fzn_file` from `mzn2fzn`

I'm not familiar with the rest of the code structure, so this may not be the best place to implement this fix

Fixed #29 